### PR TITLE
Accessibility (a11y) pass

### DIFF
--- a/_includes/list-card.html
+++ b/_includes/list-card.html
@@ -3,7 +3,7 @@
 {%- assign img = item.hero | default: item.image -%}
 <a href="{{ item.url | relative_url }}" class="flex rounded-card bg-card text-card-ink shadow-card overflow-hidden hover:opacity-95">
   <div class="flex-1 min-w-0 p-6 flex flex-col min-h-[11rem]">
-    <h3 class="text-lg desk:text-xl font-bold leading-snug">{{ item.title }}</h3>
+    <h2 class="text-lg desk:text-xl font-bold leading-snug">{{ item.title }}</h2>
     {%- if item.subtitle -%}
     <p class="mt-2 text-sm text-card-muted line-clamp-2">{{ item.subtitle }}</p>
     {%- endif -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,23 +3,25 @@
   over this top-left area, so the inner reserves space at the top for it. {%- endcomment -%}
   <div class="app-sidebar-inner flex flex-col p-8 desk:p-10">
   {%- comment -%} Nav — right-aligned, bold (Ubuntu Mono Bold 20px) {%- endcomment -%}
-  <nav class="mt-28 flex flex-col items-end gap-3 text-xl">
+  <nav class="mt-28 flex flex-col items-end gap-3 text-xl" aria-label="Primary">
     {%- for item in site.data.nav -%}
-    <a class="nav-link" href="{{ item.url | relative_url }}"{% if item.new_tab %} target="_blank" rel="noopener"{% endif %}>{{ item.label }}</a>
+    <a class="nav-link" href="{{ item.url | relative_url }}"{% if item.new_tab %} target="_blank" rel="noopener"{% endif %}>{{ item.label }}{% if item.new_tab %}<span class="sr-only"> (opens in a new tab)</span>{% endif %}</a>
     {%- endfor -%}
   </nav>
 
   {%- comment -%} Social — bottom, left-aligned grid of 40px icons {%- endcomment -%}
   {%- if site.data.social and site.data.social.size > 0 -%}
-  <ul class="mt-auto pt-12 grid grid-cols-4 gap-4 justify-items-start">
+  <nav aria-label="Social" class="mt-auto pt-12">
+  <ul class="grid grid-cols-4 gap-4 justify-items-start">
     {%- for s in site.data.social -%}
     <li>
-      <a href="{{ s.url | relative_url }}" aria-label="{{ s.name }}" class="grid place-items-center size-10 rounded-full hover:opacity-80 transition-opacity" style="background-color: {{ s.bg | default: '#ffffff' }}; color: {{ s.fg | default: '#000000' }}">
+      <a href="{{ s.url | relative_url }}" aria-label="{{ s.name }}" target="_blank" rel="noopener" class="app-social-link grid place-items-center size-10 rounded-full hover:opacity-80 transition-opacity" style="background-color: {{ s.bg | default: '#ffffff' }}; color: {{ s.fg | default: '#000000' }}">
         {%- include icon.html name=s.icon class="w-5 h-5" -%}
       </a>
     </li>
     {%- endfor -%}
   </ul>
+  </nav>
   {%- endif -%}
   </div>
 </aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,13 +16,18 @@
   <link rel="alternate" type="application/atom+xml" href="{{ '/work/feed.xml' | absolute_url }}" title="{{ site.title }} | Work">
 </head>
 <body class="bg-panel text-ink font-mono antialiased">
+  {%- comment -%} Visible-on-focus skip link so keyboard users can jump past the
+  nav toggle straight to the page content. {%- endcomment -%}
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
   {%- comment -%} Pure-CSS collapse: the hidden checkbox holds the state and the
   avatar <label> toggles it — no JavaScript required. Defaults come from CSS
-  (desktop open, mobile collapsed). {%- endcomment -%}
-  <input type="checkbox" id="nav-toggle" class="sr-only" aria-label="Toggle navigation">
-  <label for="nav-toggle" class="app-avatar" title="Toggle navigation">
+  (desktop open, mobile collapsed). The checkbox is the real control, so it carries
+  the accessible name and the expanded/collapsed state announcement. {%- endcomment -%}
+  <input type="checkbox" id="nav-toggle" class="sr-only" aria-label="Navigation menu" aria-controls="app-sidebar">
+  <label for="nav-toggle" class="app-avatar" aria-hidden="true">
     {%- if site.avatar -%}
-    <img src="{{ site.avatar | relative_url }}" alt="{{ site.title }}">
+    <img src="{{ site.avatar | relative_url }}" alt="">
     {%- else -%}
     <span class="app-avatar-fallback">AB</span>
     {%- endif -%}
@@ -32,7 +37,7 @@
 
   <div class="app-shell">
     {% include sidebar.html %}
-    <main class="app-main px-6 pt-24 pb-12 desk:px-16 desk:py-16">
+    <main id="main-content" class="app-main px-6 pt-24 pb-12 desk:px-16 desk:py-16">
       <div class="app-main-inner">
         {{ content }}
       </div>

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -56,6 +56,6 @@ page.filter_value    = the category slug or ISO date (optional)
   {%- for item in items -%}
     {%- include list-card.html item=item -%}
   {%- else -%}
-    <p class="text-ink/60">Nothing here yet.</p>
+    <p class="text-ink/70">Nothing here yet.</p>
   {%- endfor -%}
 </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {%- comment -%} Hero is mandatory for work (also enforced at build time). {%- endcomment -%}
 <div class="-mx-6 -mt-20 desk:-mx-16 desk:-mt-16">
-  <img src="{{ page.hero | relative_url }}" alt="{{ page.title }}" class="w-full h-64 desk:h-[420px] object-cover">
+  <img src="{{ page.hero | relative_url }}" alt="" class="w-full h-64 desk:h-[420px] object-cover">
 </div>
 
 <article class="mt-10">
@@ -12,10 +12,10 @@ layout: default
   {%- if page.client or page['for'] -%}
   <div class="mt-4 flex justify-between gap-6">
     {%- if page.client -%}
-    <div><div class="text-sm text-ink/60">Client</div><div class="font-bold">{{ page.client }}</div></div>
+    <div><div class="text-sm text-ink/70">Client</div><div class="font-bold">{{ page.client }}</div></div>
     {%- endif -%}
     {%- if page['for'] -%}
-    <div class="text-right"><div class="text-sm text-ink/60">For</div><div class="font-bold">{{ page['for'] }}</div></div>
+    <div class="text-right"><div class="text-sm text-ink/70">For</div><div class="font-bold">{{ page['for'] }}</div></div>
     {%- endif -%}
   </div>
   {%- endif -%}

--- a/_tailwind/app.css
+++ b/_tailwind/app.css
@@ -23,15 +23,18 @@
   --color-card-ink: #000000; /* card title/body text */
   --color-card-muted: #555555; /* card subtitle/secondary */
 
-  /* Category pill palette (exact hex, 8 colors, cycled by index) */
-  --color-cat-1: #9300d9;
-  --color-cat-2: #008e1f;
-  --color-cat-3: #008b94;
-  --color-cat-4: #c00000;
-  --color-cat-5: #7eaa00;
-  --color-cat-6: #d85b00;
-  --color-cat-7: #00b071;
-  --color-cat-8: #d1007e;
+  /* Category pill palette (8 colors, cycled by index). White chip label text must
+     meet WCAG AA (>=4.5:1 for normal text); the olive/green/teal/orange hues from
+     the Figma palette failed, so they are darkened just enough to pass while keeping
+     the same hue. Passing originals (cat-1/4/8) are left untouched. */
+  --color-cat-1: #9300d9; /* 6.48:1 */
+  --color-cat-2: #00881e; /* was #008e1f (4.30) -> 4.63:1 */
+  --color-cat-3: #00838b; /* was #008b94 (4.10) -> 4.55:1 */
+  --color-cat-4: #c00000; /* 6.48:1 */
+  --color-cat-5: #608100; /* was #7eaa00 (2.75) -> 4.53:1 */
+  --color-cat-6: #c25200; /* was #d85b00 (3.88) -> 4.67:1 */
+  --color-cat-7: #008656; /* was #00b071 (2.82) -> 4.62:1 */
+  --color-cat-8: #d1007e; /* 5.23:1 */
 
   /* Radii & shadow */
   --radius-pill: 8px; /* category pills */
@@ -44,14 +47,45 @@
 }
 
 @layer components {
-  /* Category pill — bg color applied per-instance via .cat-N (see below) */
+  /* Category pill — bg color applied per-instance via .cat-N (see below).
+     min-h keeps the tap target >=24px even for short labels. */
   .chip {
-    @apply inline-flex items-center justify-center rounded-pill px-4 py-1.5 text-white;
+    @apply inline-flex items-center justify-center rounded-pill px-4 py-1.5 min-h-[2rem] text-white;
   }
-  /* Sidebar nav link — right-aligned, bold (Ubuntu Mono Bold 20px in design) */
+  /* Sidebar nav link — right-aligned, bold (Ubuntu Mono Bold 20px in design).
+     py keeps a comfortable >=44px tap target. */
   .nav-link {
-    @apply block text-right font-bold tracking-wide hover:opacity-70;
+    @apply block py-1.5 text-right font-bold tracking-wide hover:opacity-70;
   }
+}
+
+/* Visible-on-focus skip link: hidden off-screen until focused, then pinned to the
+   top-left corner above everything so keyboard users can jump to the content. */
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 60;
+  transform: translateY(-150%);
+  padding: 0.5rem 1rem;
+  background-color: #fff;
+  color: #000;
+  font-weight: 700;
+  border-radius: 0.5rem;
+  transition: transform 0.2s ease;
+}
+.skip-link:focus { transform: translateY(0); outline: 2px solid #000; outline-offset: 2px; }
+
+/* Consistent, visible focus indicator for every interactive control. */
+.nav-link:focus-visible,
+.chip:focus-visible,
+.app-social-link:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+.rich a:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 /* ---- Article / markdown body (no typography plugin) ---------------------- */
@@ -93,9 +127,17 @@
   overflow-y: auto;
   background-color: var(--color-sidebar);
   transform: translateY(-100%);
-  transition: transform 0.35s ease;
+  /* visibility:hidden when collapsed removes the off-screen nav links from the tab
+     order and the accessibility tree. It is delayed by the slide duration so the
+     close animation still plays; opening flips it to visible immediately. */
+  visibility: hidden;
+  transition: transform 0.35s ease, visibility 0s linear 0.35s;
 }
-#nav-toggle:checked ~ .app-shell .app-sidebar { transform: translateY(0); }
+#nav-toggle:checked ~ .app-shell .app-sidebar {
+  transform: translateY(0);
+  visibility: visible;
+  transition: transform 0.35s ease, visibility 0s linear 0s;
+}
 
 /* Dim backdrop behind the open mobile menu (a <label> that closes on tap). */
 .app-scrim {
@@ -172,9 +214,18 @@
     width: 360px;
     overflow: hidden;
     flex-shrink: 0;
-    transition: width 0.35s ease;
+    /* Desktop default is open -> visible; delay re-hiding until the collapse
+       animation finishes (see checked rule). */
+    visibility: visible;
+    transition: width 0.35s ease, visibility 0s linear 0s;
   }
-  #nav-toggle:checked ~ .app-shell .app-sidebar { width: 0; transform: none; }
+  #nav-toggle:checked ~ .app-shell .app-sidebar {
+    width: 0;
+    transform: none;
+    /* Collapsed: pull the nav links out of the tab order / a11y tree once hidden. */
+    visibility: hidden;
+    transition: width 0.35s ease, visibility 0s linear 0.35s;
+  }
   .app-sidebar-inner {
     width: 360px;
     height: 100%;
@@ -205,3 +256,15 @@
 .cat-6 { background-color: var(--color-cat-6); }
 .cat-7 { background-color: var(--color-cat-7); }
 .cat-8 { background-color: var(--color-cat-8); }
+
+/* Respect users who ask for less motion: drop the sidebar slide / avatar resize /
+   scrim fade transitions. Visibility still toggles instantly (kept here so the
+   collapsed nav stays out of the a11y tree), and the menu snaps open/closed. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Full WCAG AA accessibility pass on the redesigned site. Builds green with `JEKYLL_ENV=production bundle exec jekyll build`; spot-checked desktop + mobile no-JS rendering in Chromium.

## Offenses found and fixes

### Landmarks & semantics
- **No skip link** — added a visible-on-focus "Skip to content" link targeting `<main id="main-content">` (`.skip-link` in CSS, slides in on focus).
- **Unlabelled nav regions** — primary nav now has `aria-label="Primary"`; social icons are wrapped in a labelled `<nav aria-label="Social">`. (`<main>`, `<aside>`, per-page `<header>` were already present.)

### Avatar toggle accessible name / state
- The avatar `<label>` was an image button whose accessible name was the site title, but it's really the menu toggle. The hidden checkbox is the actual control, so it now carries `aria-label="Navigation menu"` + `aria-controls="app-sidebar"`, and the `<label>` is `aria-hidden="true"` to avoid a duplicate announcement. SRs announce a sensible name + checked/unchecked (open/closed) state. The checkbox is `.sr-only` (clip-based, not `display:none`), so it stays keyboard-focusable.
- Avatar `<img>` was `alt="{{ site.title }}"` inside that toggle — now `alt=""` (decorative).

### Collapsed nav still focusable (the known issue)
- When collapsed, nav links stayed in the tab order / a11y tree (mobile `translateY(-100%)` off-screen; desktop `width:0` + `overflow:hidden`). Added `visibility:hidden` on the collapsed sidebar, restored on `#nav-toggle:checked`, with `transition: ... visibility 0s linear 0.35s` so the slide/width animation still plays before the links are removed from focus.

### Color contrast (WCAG AA)
White chip label text failed AA on several brand colors. Darkened them (same hue) to ≥4.5:1; passing colors (cat-1/4/8) left as-is:
- cat-2 `#008e1f` (4.30) → `#00881e` (4.63)
- cat-3 `#008b94` (4.10) → `#00838b` (4.55)
- cat-5 `#7eaa00` (2.75) → `#608100` (4.53)
- cat-6 `#d85b00` (3.88) → `#c25200` (4.67)
- cat-7 `#00b071` (2.82) → `#008656` (4.62)
- Muted labels `text-ink/60` (3.88 on `#555`) → `text-ink/70` (4.64) in list/project layouts.
- Verified passing and left unchanged: ink on `#555` (7.46), card `#000` on `#ddd` (15.46), card-muted `#555` on `#ddd` (5.49), and the "All" pill (white on `bg-white/15` over `#555` = 5.10).

### Focus visibility
- Added `:focus-visible` outlines for nav links, chips, social links, and rich-body links (the avatar toggle already had one).

### Heading order
- `list-card` heading was `h3` directly under the page `h1` (skipped h2) → changed to `h2`. Other layouts already had clean order; one `h1` per page confirmed.

### Reduced motion
- Added a `@media (prefers-reduced-motion: reduce)` block that disables the 0.35s transforms/animations (visibility toggle kept instant so collapsed nav stays out of the a11y tree).

### Tap targets
- Chips get `min-h-[2rem]`; nav links get vertical padding for comfortable ≥24–44px targets.

### External links
- Social links now have `target="_blank" rel="noopener"`; new-tab nav items already had `rel="noopener"` and now also get an `sr-only` "(opens in a new tab)" hint.

## Deliberately left
- Brand colors cat-1/4/8 unchanged (already pass AA).
- `lang="en"` and per-page `<title>` were already correct — no change.
- Did not alter content, images, or the visual design beyond the minimal contrast tweaks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)