### PR TITLE
Extract inlined HTML into includes; de-inline the 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,24 +2,9 @@
 permalink: /404.html
 layout: default
 ---
-
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
-</div>
+<section class="text-center">
+  <h1 class="font-head text-6xl desk:text-8xl leading-none">404</h1>
+  <p class="mt-6 text-xl font-bold">Page not found :(</p>
+  <p class="mt-2 text-ink/70">The page you're after has moved or never existed.</p>
+  <a href="{{ '/' | relative_url }}" class="mt-8 inline-block font-bold hover:underline hover:decoration-2 underline-offset-4">Back home</a>
+</section>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ Top-level pages are Markdown/HTML at the repo root (`index.markdown`, `contact.m
 
 ## Layouts, includes & data
 
-- **`_layouts/`**: `default.html` (shell: sidebar + main + footer, theme/nav toggles, head), `home.html`, `list.html` (shared by `/work`, `/posts`, and generated category/date pages via `page.filter_type`/`page.filter_value`), `post.html`, `project.html`.
-- **`_includes/`**: `sidebar.html`, `icon.html` (wrapper that inlines the vendored `_includes/icons/*.svg` and injects the size class), `category-chip.html`, `category-list.html`, `list-card.html`, `featured-card.html`, `ext-link.html` + `ext-arrow.html` (canonical external/new-tab link — see DESIGN.md §5).
+- **`_layouts/`**: `default.html` (thin shell skeleton that just composes the includes below: `head.html` + `app-chrome.html` + `sidebar.html` + main/`content` + `footer.html`), `home.html`, `list.html` (shared by `/work`, `/posts`, and generated category/date pages via `page.filter_type`/`page.filter_value`), `post.html`, `project.html`.
+- **`_includes/`**: shell partials — `head.html` (`<head>`: meta, font preloads, feed links, no-flash theme script), `app-chrome.html` (skip link, no-JS nav/theme toggles + theme-sync script, avatar menu button, scrim), `sidebar.html`, `footer.html` (colophon). Components — `icon.html` (wrapper that inlines the vendored `_includes/icons/*.svg` and injects the size class), `category-chip.html`, `category-list.html`, `list-card.html`, `featured-card.html`, `social-link.html` (labelled brand social badge on Contact), `ext-link.html` + `ext-arrow.html` (canonical external/new-tab link — see DESIGN.md §5).
 - **`_data/`**: `nav.yml` (nav items; `new_tab: true` for off-site), `social.yml` (full brand-colored set for the Contact page; sidebar shows only email + GitHub, monochrome).
 
 ## Fonts

--- a/_includes/app-chrome.html
+++ b/_includes/app-chrome.html
@@ -1,6 +1,7 @@
-{%- comment -%} App chrome that floats over the shell: the skip link, the no-JS
-nav/theme toggles (hidden checkboxes + labelled controls), the avatar menu button,
-and the mobile backdrop. Pulled out of default.html so the body reads as a skeleton. {%- endcomment -%}
+{%- comment -%} Body-level chrome that floats over the shell (fixed/absolute). It must
+render as a sibling BEFORE .app-shell: the no-JS toggles work via the CSS sibling
+combinator — `#nav-toggle:checked ~ .app-shell` (and ~ .app-avatar / ~ .app-scrim),
+`#theme-toggle:checked ~ …`. See each element's comment below for the specifics. {%- endcomment -%}
 {%- comment -%} Visible-on-focus skip link so keyboard users can jump past the
 nav toggle straight to the page content. {%- endcomment -%}
 <a href="#main-content" class="skip-link">Skip to content</a>

--- a/_includes/app-chrome.html
+++ b/_includes/app-chrome.html
@@ -1,0 +1,48 @@
+{%- comment -%} App chrome that floats over the shell: the skip link, the no-JS
+nav/theme toggles (hidden checkboxes + labelled controls), the avatar menu button,
+and the mobile backdrop. Pulled out of default.html so the body reads as a skeleton. {%- endcomment -%}
+{%- comment -%} Visible-on-focus skip link so keyboard users can jump past the
+nav toggle straight to the page content. {%- endcomment -%}
+<a href="#main-content" class="skip-link">Skip to content</a>
+
+{%- comment -%} Pure-CSS collapse: the hidden checkbox holds the state and the
+avatar <label> toggles it — no JavaScript required. Defaults come from CSS
+(desktop open, mobile collapsed). The checkbox is the real control, so it carries
+the accessible name and the expanded/collapsed state announcement. {%- endcomment -%}
+<input type="checkbox" id="nav-toggle" class="sr-only" aria-label="Navigation menu" aria-controls="app-sidebar">
+{%- comment -%} Light/dark theme switch, mirroring the nav-toggle pattern: a
+visually-hidden checkbox holds the state and the labelled button flips it. Baseline
+is CSS-only (`html:has(#theme-toggle:checked)`) so it works with JS disabled. The
+script below is progressive enhancement: it syncs the checkbox to the resolved
+theme (saved choice / OS default, set in <head>) and persists the user's choice. {%- endcomment -%}
+<input type="checkbox" id="theme-toggle" class="sr-only" aria-label="Switch to light theme">
+<script>
+  (function () {
+    var box = document.getElementById("theme-toggle");
+    box.checked = document.documentElement.dataset.theme === "light";
+    box.addEventListener("change", function () {
+      var light = box.checked;
+      document.documentElement.dataset.theme = light ? "light" : "dark";
+      try { localStorage.setItem("theme", light ? "light" : "dark"); } catch (e) {}
+    });
+  })();
+</script>
+<label for="nav-toggle" class="app-avatar" aria-hidden="true">
+  {%- if site.avatar -%}
+  <img src="{{ site.avatar | relative_url }}" alt="">
+  {%- else -%}
+  <span class="app-avatar-fallback">AB</span>
+  {%- endif -%}
+  {%- comment -%} Persistent hamburger badge (desktop) so it's clearly the menu
+  toggle in both states; animates to an X when the menu is open. {%- endcomment -%}
+  <span class="app-menu-badge" aria-hidden="true"><span class="app-menu-bars"></span></span>
+</label>
+{%- comment -%} Theme switch button, pinned next to the avatar badge. The sun glyph
+shows in dark mode (tap to go light); the moon shows in light mode (tap to go dark).
+Both glyphs are rendered; CSS swaps them on :checked. {%- endcomment -%}
+<label for="theme-toggle" class="app-theme-toggle">
+  {%- include icon.html name="sun" class="app-theme-icon app-theme-icon--sun" -%}
+  {%- include icon.html name="moon" class="app-theme-icon app-theme-icon--moon" -%}
+</label>
+{%- comment -%} Backdrop behind the open mobile menu; tapping it closes (no JS). {%- endcomment -%}
+<label for="nav-toggle" class="app-scrim" aria-hidden="true"></label>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,6 @@
+{%- comment -%} Site colophon: build credits + license + feeds + source, one line,
+pinned to the bottom of the main column. All links are external (ext-link). {%- endcomment -%}
+{%- assign feed_url = '/feed.xml' | relative_url -%}
+<footer class="app-footer text-xs text-ink/70">
+  <p>Built with {% include ext-link.html href="https://jekyllrb.com/" label="Jekyll" %} + {% include ext-link.html href="https://tailwindcss.com/" label="Tailwind" %} + <span aria-hidden="true">❤️</span> + <span aria-hidden="true">🚬</span> · set in {% include ext-link.html href="https://monaspace.githubnext.com/" label="Monaspace" %} · {% include ext-link.html href="https://creativecommons.org/licenses/by-nc-sa/4.0/" label="CC BY-NC-SA 4.0" %} · {% include ext-link.html href=feed_url label="RSS" %} · {% include ext-link.html href=site.repo_url label="Source" %} · Last built {{ site.time | date: "%Y-%m-%d" }}</p>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 {%- comment -%} <head> contents: metadata, font preloads, stylesheet, feed
 autodiscovery, and the no-flash theme bootstrap (resolves the theme before paint,
-before the body renders). Kept out of default.html so the shell stays readable. {%- endcomment -%}
+before the body renders). {%- endcomment -%}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,25 @@
+{%- comment -%} <head> contents: metadata, font preloads, stylesheet, feed
+autodiscovery, and the no-flash theme bootstrap (resolves the theme before paint,
+before the body renders). Kept out of default.html so the shell stays readable. {%- endcomment -%}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+{% if page.description or site.description %}
+<meta name="description" content="{{ page.description | default: site.description | strip_newlines }}">
+{% endif %}
+<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ '/assets/fonts/monaspace-neon-400.woff2' | relative_url }}">
+<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ '/assets/fonts/monaspace-radon-700.woff2' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+{%- feed_meta -%}
+{%- comment -%} feed_meta only advertises the posts feed; advertise the work feed too. {%- endcomment -%}
+<link rel="alternate" type="application/atom+xml" href="{{ '/work/feed.xml' | absolute_url }}" title="{{ site.title }} | Work">
+<script>
+  /* Progressive enhancement (the theme also works without JS via the checkbox).
+     Resolve the initial theme before paint — saved choice, else OS preference —
+     so there's no flash. The checkbox is synced to this in the body. */
+  try {
+    var t = localStorage.getItem("theme")
+         || (matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+    if (t === "light") document.documentElement.dataset.theme = "light";
+  } catch (e) {}
+</script>

--- a/_includes/social-link.html
+++ b/_includes/social-link.html
@@ -1,0 +1,11 @@
+{%- comment -%} Labelled, brand-colored social badge for the Contact page. Param:
+item (a _data/social entry: name, url, icon, bg, fg). The sidebar shows the same
+links monochrome + unlabelled; this is the full labelled treatment. {%- endcomment -%}
+{%- assign s = include.item -%}
+<a href="{{ s.url | relative_url }}" target="_blank" rel="noopener"
+   class="app-social-link group flex items-center gap-4 rounded-card px-2 py-2 -mx-2 hover:opacity-80 transition-opacity">
+  <span class="grid place-items-center size-10 rounded-full shrink-0" style="background-color: {{ s.bg | default: '#ffffff' }}; color: {{ s.fg | default: '#000000' }}">
+    {%- include icon.html name=s.icon class="w-5 h-5" -%}
+  </span>
+  <span class="text-lg font-bold">{{ s.name }}<span class="sr-only"> (opens in a new tab)</span></span>
+</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,75 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
-  {% if page.description or site.description %}
-  <meta name="description" content="{{ page.description | default: site.description | strip_newlines }}">
-  {% endif %}
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="{{ '/assets/fonts/monaspace-neon-400.woff2' | relative_url }}">
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="{{ '/assets/fonts/monaspace-radon-700.woff2' | relative_url }}">
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-  {%- feed_meta -%}
-  {%- comment -%} feed_meta only advertises the posts feed; advertise the work feed too. {%- endcomment -%}
-  <link rel="alternate" type="application/atom+xml" href="{{ '/work/feed.xml' | absolute_url }}" title="{{ site.title }} | Work">
-  <script>
-    /* Progressive enhancement (the theme also works without JS via the checkbox).
-       Resolve the initial theme before paint — saved choice, else OS preference —
-       so there's no flash. The checkbox is synced to this in the body. */
-    try {
-      var t = localStorage.getItem("theme")
-           || (matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
-      if (t === "light") document.documentElement.dataset.theme = "light";
-    } catch (e) {}
-  </script>
+  {%- include head.html -%}
 </head>
 <body class="bg-panel text-ink font-mono antialiased">
-  {%- comment -%} Visible-on-focus skip link so keyboard users can jump past the
-  nav toggle straight to the page content. {%- endcomment -%}
-  <a href="#main-content" class="skip-link">Skip to content</a>
-
-  {%- comment -%} Pure-CSS collapse: the hidden checkbox holds the state and the
-  avatar <label> toggles it — no JavaScript required. Defaults come from CSS
-  (desktop open, mobile collapsed). The checkbox is the real control, so it carries
-  the accessible name and the expanded/collapsed state announcement. {%- endcomment -%}
-  <input type="checkbox" id="nav-toggle" class="sr-only" aria-label="Navigation menu" aria-controls="app-sidebar">
-  {%- comment -%} Light/dark theme switch, mirroring the nav-toggle pattern: a
-  visually-hidden checkbox holds the state and the labelled button flips it. Baseline
-  is CSS-only (`html:has(#theme-toggle:checked)`) so it works with JS disabled. The
-  script below is progressive enhancement: it syncs the checkbox to the resolved
-  theme (saved choice / OS default, set in <head>) and persists the user's choice. {%- endcomment -%}
-  <input type="checkbox" id="theme-toggle" class="sr-only" aria-label="Switch to light theme">
-  <script>
-    (function () {
-      var box = document.getElementById("theme-toggle");
-      box.checked = document.documentElement.dataset.theme === "light";
-      box.addEventListener("change", function () {
-        var light = box.checked;
-        document.documentElement.dataset.theme = light ? "light" : "dark";
-        try { localStorage.setItem("theme", light ? "light" : "dark"); } catch (e) {}
-      });
-    })();
-  </script>
-  <label for="nav-toggle" class="app-avatar" aria-hidden="true">
-    {%- if site.avatar -%}
-    <img src="{{ site.avatar | relative_url }}" alt="">
-    {%- else -%}
-    <span class="app-avatar-fallback">AB</span>
-    {%- endif -%}
-    {%- comment -%} Persistent hamburger badge (desktop) so it's clearly the menu
-    toggle in both states; animates to an X when the menu is open. {%- endcomment -%}
-    <span class="app-menu-badge" aria-hidden="true"><span class="app-menu-bars"></span></span>
-  </label>
-  {%- comment -%} Theme switch button, pinned next to the avatar badge. The sun glyph
-  shows in dark mode (tap to go light); the moon shows in light mode (tap to go dark).
-  Both glyphs are rendered; CSS swaps them on :checked. {%- endcomment -%}
-  <label for="theme-toggle" class="app-theme-toggle">
-    {%- include icon.html name="sun" class="app-theme-icon app-theme-icon--sun" -%}
-    {%- include icon.html name="moon" class="app-theme-icon app-theme-icon--moon" -%}
-  </label>
-  {%- comment -%} Backdrop behind the open mobile menu; tapping it closes (no JS). {%- endcomment -%}
-  <label for="nav-toggle" class="app-scrim" aria-hidden="true"></label>
+  {%- include app-chrome.html -%}
 
   <div class="app-shell">
     {% include sidebar.html %}
@@ -77,10 +12,7 @@
       <div class="app-main-inner">
         {{ content }}
       </div>
-      {%- assign feed_url = '/feed.xml' | relative_url -%}
-      <footer class="app-footer text-xs text-ink/70">
-        <p>Built with {% include ext-link.html href="https://jekyllrb.com/" label="Jekyll" %} + {% include ext-link.html href="https://tailwindcss.com/" label="Tailwind" %} + <span aria-hidden="true">❤️</span> + <span aria-hidden="true">🚬</span> · set in {% include ext-link.html href="https://monaspace.githubnext.com/" label="Monaspace" %} · {% include ext-link.html href="https://creativecommons.org/licenses/by-nc-sa/4.0/" label="CC BY-NC-SA 4.0" %} · {% include ext-link.html href=feed_url label="RSS" %} · {% include ext-link.html href=site.repo_url label="Source" %} · Last built {{ site.time | date: "%Y-%m-%d" }}</p>
-      </footer>
+      {%- include footer.html -%}
     </main>
   </div>
 </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,10 +4,12 @@
   {%- include head.html -%}
 </head>
 <body class="bg-panel text-ink font-mono antialiased">
+  {%- comment -%} Order matters: app-chrome must precede .app-shell so the no-JS
+  nav/theme toggles reach it via CSS `#nav-toggle:checked ~ .app-shell` etc. {%- endcomment -%}
   {%- include app-chrome.html -%}
 
   <div class="app-shell">
-    {% include sidebar.html %}
+    {%- include sidebar.html -%}
     <main id="main-content" class="app-main px-6 pt-24 pb-12 desk:px-16 desk:py-16">
       <div class="app-main-inner">
         {{ content }}

--- a/contact.md
+++ b/contact.md
@@ -34,15 +34,7 @@ description: Get in touch with Akshay Bhalotia — email or find me on any of th
   <h2 class="section-title mt-16">Find me elsewhere</h2>
   <ul class="mt-6 grid grid-cols-1 xs:grid-cols-2 gap-4">
     {%- for s in site.data.social -%}
-    <li>
-      <a href="{{ s.url | relative_url }}" target="_blank" rel="noopener"
-         class="app-social-link group flex items-center gap-4 rounded-card px-2 py-2 -mx-2 hover:opacity-80 transition-opacity">
-        <span class="grid place-items-center size-10 rounded-full shrink-0" style="background-color: {{ s.bg | default: '#ffffff' }}; color: {{ s.fg | default: '#000000' }}">
-          {%- include icon.html name=s.icon class="w-5 h-5" -%}
-        </span>
-        <span class="text-lg font-bold">{{ s.name }}<span class="sr-only"> (opens in a new tab)</span></span>
-      </a>
-    </li>
+    <li>{%- include social-link.html item=s -%}</li>
     {%- endfor -%}
   </ul>
   {%- endif -%}


### PR DESCRIPTION
Refactors inlined HTML into reusable includes so `default.html` reads as a thin skeleton, and rebuilds the off-brand 404 page.

## Extractions
| New include | From | What |
|---|---|---|
| `_includes/head.html` | `default.html` | Whole `<head>`: meta, font preloads, feed links, no-flash theme script |
| `_includes/app-chrome.html` | `default.html` | Skip link, no-JS nav/theme toggles + theme-sync script, avatar menu button, mobile scrim |
| `_includes/footer.html` | `default.html` | Colophon |
| `_includes/social-link.html` | `contact.md` | Labelled brand social badge (loop body → one-line include) |

`_layouts/default.html` is now ~18 lines that just compose `head` + `app-chrome` + `sidebar` + content + `footer`.

## 404
Dropped the leftover **minima-era inline `<style>`** (generic `.container`, non-theme-aware `h1`) and rebuilt the page with design-system classes — `font-head` display number, theme tokens, a focusable "Back home" link. This is the only visual change.

## Verification
- `JEKYLL_ENV=production npm run build` is clean.
- Rendered output checked: shell composes correctly (head/chrome/footer markers present), contact social badges render with brand colors, 404 ships the new markup with no `<style>`, and Tailwind emits the new 404 utilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)