### PR TITLE
feat: syntax highlighting for code blocks (gruvbox)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,6 +19,9 @@ For build/tooling and content architecture, see `CLAUDE.md`. This file is design
   (persistence, the typewriter). Toggles are CSS (`:checked`, `:has()`, `~`).
 - **Restraint, one signature.** The palette is monochrome; the one deliberate
   flourish is the hero (handwriting display + typed-in headline with a cursor).
+  The single sanctioned colour exception is **syntax highlighting**: code blocks
+  carry a functional gruvbox palette because readability there beats purity —
+  everything else stays monochrome (§5).
 - **Accessibility is a floor, not a feature.** WCAG AA contrast minimum,
   `:focus-visible` everywhere, `prefers-reduced-motion` respected, semantic
   landmarks, skip link.
@@ -61,7 +64,8 @@ its tiers widened so it doesn't crowd near-white.
 | `--color-social-border` | `transparent` | `rgb(0 0 0 / .18)` | Contact social badge border |
 
 There is intentionally **no accent hue** and **no per-category color** — interactive
-state is carried by underline / inversion / opacity, not color.
+state is carried by underline / inversion / opacity, not color. (The one exception
+is syntax highlighting inside code blocks — see §5.)
 
 ### Verified contrast (WCAG)
 
@@ -194,10 +198,26 @@ so it adapts to theme), and an sr-only "(opens in a new tab)". Use the `ext-link
 include for standalone links; the nav applies `.ext-arrow` to `new_tab` items.
 Icon-only social links opt out.
 
-### Code (`.rich code`, `.rich pre`)
+### Code (`.rich code`, `.rich pre`, `_tailwind/highlight.css`)
 Theme-aware surface `--color-code-bg` (near-black box in dark, warm near-white in
 light) + a hairline border, so both the box and its text stay crisp in both themes.
 Coding ligatures on (see §3).
+
+**Syntax highlighting** happens at **build time** — kramdown + Rouge emit token
+`<span>`s inside `<figure class="highlight">`, so it needs **zero JS** and a no-JS
+visitor sees fully-coloured code (the one place colour is allowed — §1). The
+gruvbox palette is mapped to theme-aware `--hl-*` tokens (dark defaults on `:root`,
+light overrides under the same `:has(#theme-toggle:checked)` / `[data-theme]`
+triggers as the rest of the theme) so it flips with the toggle. Every token colour
+is **AA-verified on `--color-code-bg`** in both modes; four light-mode hues
+(comment/string/type/class) are darkened from stock gruvbox-light to clear 4.5:1.
+Base text, operators and punctuation inherit `--color-ink`. **Inline** `` `code` ``
+has no language, so it is not tokenised — it keeps the plain code surface.
+
+A **line-number gutter** and **copy button** are added by `_includes/code-enhance.html`
+(progressive enhancement, §6): with JS off they're simply absent — you still get the
+highlighted block. The gutter is `aria-hidden`, non-selectable, and `position:sticky`
+so it stays put while the code scrolls.
 
 ### Sidebar socials vs Contact page
 Sidebar keeps two **monochrome** essentials (email + GitHub). The full, brand-colored,
@@ -258,4 +278,10 @@ a 2px `--color-focus` outline on `:focus-visible`.
 - **New surface/box:** reuse an existing surface token; if it needs its own, add a
   paired dark/light token like `--color-code-bg` rather than an overlay (overlays go
   muddy on one theme).
-- **Never** introduce an accent hue or per-category color without revisiting §1.
+- **Change the syntax-highlight theme:** regenerate the token colours with
+  `bundle exec rougify style <theme>.dark` / `.light`, map them onto the `--hl-*`
+  tokens in `_tailwind/highlight.css`, and re-check each against `--color-code-bg`
+  in both modes (AA 4.5:1) — darken any that fall short, as the light gruvbox hues
+  needed. Don't hardcode per-token colours outside the `--hl-*` tokens.
+- **Never** introduce an accent hue or per-category color without revisiting §1
+  (syntax highlighting in code blocks is the one sanctioned exception).

--- a/_includes/code-enhance.html
+++ b/_includes/code-enhance.html
@@ -1,0 +1,50 @@
+{%- comment -%} Progressive enhancement for code blocks: a line-number gutter and a
+copy button. Highlighting itself is build-time (Rouge) — this only adds chrome, so
+with JS disabled (or if this fails) you still get the fully-highlighted block, i.e.
+today's experience, never worse. Returns immediately on pages with no code. {%- endcomment -%}
+<script>
+  (function () {
+    var blocks = document.querySelectorAll(".rich figure.highlight");
+    if (!blocks.length) return;
+    var canCopy = !!(navigator.clipboard && navigator.clipboard.writeText);
+    Array.prototype.forEach.call(blocks, function (fig) {
+      var pre = fig.querySelector("pre");
+      var code = fig.querySelector("code");
+      if (!pre || !code) return;
+      var text = code.textContent.replace(/\n+$/, "");
+
+      // Line-number gutter (skip trivial single-line blocks).
+      var lines = text.split("\n").length;
+      if (lines > 1) {
+        var nums = [];
+        for (var i = 1; i <= lines; i++) nums.push(i);
+        var gutter = document.createElement("span");
+        gutter.className = "code-lines";
+        gutter.setAttribute("aria-hidden", "true");
+        gutter.textContent = nums.join("\n");
+        pre.insertBefore(gutter, code);
+        fig.classList.add("has-lines");
+      }
+
+      // Copy button (only when the Clipboard API is available + permitted).
+      if (canCopy) {
+        var btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "code-copy";
+        btn.textContent = "Copy";
+        btn.setAttribute("aria-label", "Copy code to clipboard");
+        btn.addEventListener("click", function () {
+          navigator.clipboard.writeText(text).then(function () {
+            btn.textContent = "Copied";
+            btn.classList.add("is-copied");
+            setTimeout(function () {
+              btn.textContent = "Copy";
+              btn.classList.remove("is-copied");
+            }, 1600);
+          }).catch(function () {});
+        });
+        fig.appendChild(btn);
+      }
+    });
+  })();
+</script>

--- a/_includes/code-enhance.html
+++ b/_includes/code-enhance.html
@@ -7,7 +7,7 @@ today's experience, never worse. Returns immediately on pages with no code. {%- 
     var blocks = document.querySelectorAll(".rich figure.highlight");
     if (!blocks.length) return;
     var canCopy = !!(navigator.clipboard && navigator.clipboard.writeText);
-    Array.prototype.forEach.call(blocks, function (fig) {
+    blocks.forEach(function (fig) {
       var pre = fig.querySelector("pre");
       var code = fig.querySelector("code");
       if (!pre || !code) return;

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,5 +17,8 @@
       {%- include footer.html -%}
     </main>
   </div>
+  {%- comment -%} Progressive enhancement for code blocks (copy button + line numbers);
+  no-op on pages without code. Highlighting itself is build-time, needs no JS. {%- endcomment -%}
+  {%- include code-enhance.html -%}
 </body>
 </html>

--- a/_tailwind/app.css
+++ b/_tailwind/app.css
@@ -38,6 +38,7 @@
   --color-card-muted: #4f4c47; /* card subtitle/secondary */
   --color-toggle: #57534d; /* avatar menu-badge disc — muted, visible on near-black */
   --color-code-bg: #14120f; /* code surface — near-black terminal box (ink text ~17:1) */
+  --code-pad: 1rem; /* code-block padding, shared by .rich pre and the line-number gutter */
   --color-card-border: transparent; /* card hairline — none in dark, set in light */
 
   /* Chrome / accent colors that aren't surfaces. These previously appeared as
@@ -114,6 +115,7 @@
 .nav-link:focus-visible,
 .chip:focus-visible,
 .app-social-link:focus-visible,
+.code-copy:focus-visible,
 .app-theme-toggle:focus-within {
   outline: 2px solid var(--color-focus);
   outline-offset: 2px;
@@ -165,7 +167,7 @@
    hairline border, so both the box and the text read crisply in both themes —
    the old flat black overlay went muddy on the light surface. */
 .rich code { background-color: var(--color-code-bg); border: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent); padding: 0.1em 0.35em; border-radius: 0.25rem; font-size: 0.9em; }
-.rich pre { background-color: var(--color-code-bg); border: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent); padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
+.rich pre { background-color: var(--color-code-bg); border: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent); padding: var(--code-pad); border-radius: 0.5rem; overflow-x: auto; }
 .rich pre code { background: none; border: 0; padding: 0; }
 
 /* Display headings use the paired Monaspace style with slightly tighter tracking. */

--- a/_tailwind/app.css
+++ b/_tailwind/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./highlight.css"; /* Rouge/gruvbox syntax-highlight tokens + code-block chrome */
 
 /* Scan Jekyll templates/content for class names (generated archive pages reuse
    _layouts, so scanning layouts/includes covers them too). */

--- a/_tailwind/highlight.css
+++ b/_tailwind/highlight.css
@@ -1,0 +1,107 @@
+/* ---- Syntax highlighting (Rouge · gruvbox) --------------------------------
+   kramdown + Rouge already emit token <span>s at build time inside
+   <figure class="highlight">, so highlighting is pure CSS: no JS, and a no-JS
+   visitor gets the fully-coloured code (identical to everyone else). Colours are
+   gruvbox — a deliberate, code-block-only exception to the otherwise monochrome
+   palette (DESIGN.md §1/§5). They're mapped to theme-aware --hl-* tokens so they
+   flip with the light/dark toggle (the same :has()/[data-theme] triggers the rest
+   of the theme uses), and every colour is AA-verified on --color-code-bg in both
+   modes. Base text, operators and punctuation inherit --color-ink (no rule). */
+
+:root {
+  --hl-comment: #928374; /* gruvbox gray   */
+  --hl-keyword: #fb4934; /* red            */
+  --hl-string:  #b8bb26; /* green          */
+  --hl-number:  #d3869b; /* purple         */
+  --hl-type:    #fabd2f; /* yellow         */
+  --hl-decl:    #fe8019; /* orange         */
+  --hl-class:   #8ec07c; /* aqua           */
+  --hl-symbol:  #83a598; /* blue           */
+}
+/* Light: gruvbox-light "faded" hues, four of them darkened to clear AA 4.5:1 on
+   the warm near-white code surface (comment/string/type/class fail otherwise). */
+html:has(#theme-toggle:checked),
+html[data-theme="light"] {
+  --hl-comment: #6f6357; /* darkened from #928374 (was 3.2:1) → 5.1:1 */
+  --hl-keyword: #9d0006;
+  --hl-string:  #6b660c; /* darkened from #79740e (was 4.2:1) → 5.2:1 */
+  --hl-number:  #8f3f71;
+  --hl-type:    #845408; /* darkened from #b57614 (was 3.3:1) → 5.6:1 */
+  --hl-decl:    #af3a03;
+  --hl-class:   #366344; /* darkened from #427b58 (was 4.4:1) → 6.1:1 */
+  --hl-symbol:  #076678;
+}
+
+/* Comments (italic, matching the site's existing faux-italic for prose emphasis). */
+.rich .highlight .c, .rich .highlight .ch, .rich .highlight .cd, .rich .highlight .cm,
+.rich .highlight .cpf, .rich .highlight .c1, .rich .highlight .cs { color: var(--hl-comment); font-style: italic; }
+/* Keywords, HTML tags, string affixes, errors. */
+.rich .highlight .k, .rich .highlight .kn, .rich .highlight .kp, .rich .highlight .kr,
+.rich .highlight .kv, .rich .highlight .nt, .rich .highlight .sa, .rich .highlight .err { color: var(--hl-keyword); }
+/* Type keywords. */
+.rich .highlight .kt { color: var(--hl-type); }
+/* Declaration keywords + string escapes. */
+.rich .highlight .kd, .rich .highlight .se { color: var(--hl-decl); }
+/* Strings + HTML/CSS attributes. */
+.rich .highlight .s, .rich .highlight .sb, .rich .highlight .sc, .rich .highlight .dl,
+.rich .highlight .sd, .rich .highlight .s2, .rich .highlight .sh, .rich .highlight .sx,
+.rich .highlight .s1, .rich .highlight .si, .rich .highlight .sr, .rich .highlight .na { color: var(--hl-string); }
+/* Numbers, constants, boolean/nil keyword-constants. */
+.rich .highlight .m, .rich .highlight .mb, .rich .highlight .mf, .rich .highlight .mh,
+.rich .highlight .mi, .rich .highlight .il, .rich .highlight .mo, .rich .highlight .mx,
+.rich .highlight .no, .rich .highlight .kc { color: var(--hl-number); }
+/* Class / namespace names, preprocessor. */
+.rich .highlight .nc, .rich .highlight .nn, .rich .highlight .cp { color: var(--hl-class); }
+/* Symbols. */
+.rich .highlight .ss { color: var(--hl-symbol); }
+/* Diff inserted / deleted lines. */
+.rich .highlight .gi { color: var(--hl-string); }
+.rich .highlight .gd { color: var(--hl-keyword); }
+
+/* ---- Progressive-enhancement chrome (added by code-enhance.html) -----------
+   The line-number gutter and copy button are injected by JS. Without JS none of
+   this exists — you get the plain highlighted block, i.e. today's experience. */
+.rich figure.highlight { position: relative; }
+
+/* Copy button: quiet chip, top-right; firms up on hover/focus. */
+.code-copy {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.3rem 0.5rem;
+  color: var(--color-ink);
+  background-color: color-mix(in srgb, var(--color-code-bg) 82%, var(--color-ink) 18%);
+  border: 1px solid color-mix(in srgb, var(--color-ink) 22%, transparent);
+  border-radius: 0.4rem;
+  opacity: 0.55;
+  cursor: pointer;
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+.rich figure.highlight:hover .code-copy,
+.code-copy:focus-visible { opacity: 1; }
+.code-copy:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
+.code-copy.is-copied { color: var(--hl-string); }
+
+/* Line-number gutter: a sticky left column so it stays put while the code scrolls
+   horizontally. aria-hidden, non-selectable, so copy/readers get only the code. */
+.rich figure.highlight.has-lines pre { display: flex; }
+.rich figure.highlight.has-lines pre > code { flex: 1 1 auto; }
+.code-lines {
+  flex: 0 0 auto;
+  position: sticky;
+  left: 0;
+  /* Bleed to the <pre>'s 1rem padding edges, then re-pad so numbers line up with
+     the code's first line and the gutter fill covers the full block height. */
+  margin: -1rem 0.9rem -1rem -1rem;
+  padding: 1rem 0.6rem 1rem 1rem;
+  background-color: var(--color-code-bg);
+  border-right: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent);
+  color: color-mix(in srgb, var(--color-ink) 45%, transparent);
+  text-align: right;
+  white-space: pre;
+  user-select: none;
+  -webkit-user-select: none;
+}

--- a/_tailwind/highlight.css
+++ b/_tailwind/highlight.css
@@ -87,16 +87,17 @@ html[data-theme="light"] {
 
 /* Line-number gutter: a sticky left column so it stays put while the code scrolls
    horizontally. aria-hidden, non-selectable, so copy/readers get only the code. */
-.rich figure.highlight.has-lines pre { display: flex; }
-.rich figure.highlight.has-lines pre > code { flex: 1 1 auto; }
+/* Move the <pre>'s padding onto the gutter and the code so the gutter sits flush
+   in the box WITHOUT a negative margin — on a flex item a negative margin-left
+   shrinks the item's footprint and drags the next item over it, which collapsed
+   the divider→code gap. Both children carry 1rem so their tops/bottoms align. */
+.rich figure.highlight.has-lines pre { display: flex; padding: 0; }
+.rich figure.highlight.has-lines pre > code { flex: 1 1 auto; padding: 1rem; }
 .code-lines {
   flex: 0 0 auto;
   position: sticky;
   left: 0;
-  /* Bleed to the <pre>'s 1rem padding edges, then re-pad so numbers line up with
-     the code's first line and the gutter fill covers the full block height. */
-  margin: -1rem 0.9rem -1rem -1rem;
-  padding: 1rem 0.6rem 1rem 1rem;
+  padding: 1rem 0.85rem 1rem 1rem; /* left aligns the numbers; right = numbers→divider gap */
   background-color: var(--color-code-bg);
   border-right: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent);
   color: color-mix(in srgb, var(--color-ink) 45%, transparent);

--- a/_tailwind/highlight.css
+++ b/_tailwind/highlight.css
@@ -1,12 +1,8 @@
 /* ---- Syntax highlighting (Rouge · gruvbox) --------------------------------
-   kramdown + Rouge already emit token <span>s at build time inside
-   <figure class="highlight">, so highlighting is pure CSS: no JS, and a no-JS
-   visitor gets the fully-coloured code (identical to everyone else). Colours are
-   gruvbox — a deliberate, code-block-only exception to the otherwise monochrome
-   palette (DESIGN.md §1/§5). They're mapped to theme-aware --hl-* tokens so they
-   flip with the light/dark toggle (the same :has()/[data-theme] triggers the rest
-   of the theme uses), and every colour is AA-verified on --color-code-bg in both
-   modes. Base text, operators and punctuation inherit --color-ink (no rule). */
+   Rouge emits token <span>s at build time inside <figure class="highlight">, so
+   this is pure CSS (no JS). The gruvbox colour exception, theme-awareness, and AA
+   contrast notes are documented in DESIGN.md §5 — the single source, not repeated
+   here. Base text, operators and punctuation inherit --color-ink (no rule). */
 
 :root {
   --hl-comment: #928374; /* gruvbox gray   */
@@ -82,7 +78,7 @@ html[data-theme="light"] {
 }
 .rich figure.highlight:hover .code-copy,
 .code-copy:focus-visible { opacity: 1; }
-.code-copy:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
+/* focus-visible outline is shared with the other controls in app.css */
 .code-copy.is-copied { color: var(--hl-string); }
 
 /* Line-number gutter: a sticky left column so it stays put while the code scrolls
@@ -90,14 +86,14 @@ html[data-theme="light"] {
 /* Move the <pre>'s padding onto the gutter and the code so the gutter sits flush
    in the box WITHOUT a negative margin — on a flex item a negative margin-left
    shrinks the item's footprint and drags the next item over it, which collapsed
-   the divider→code gap. Both children carry 1rem so their tops/bottoms align. */
+   the divider→code gap. Both children carry --code-pad so their tops/bottoms align. */
 .rich figure.highlight.has-lines pre { display: flex; padding: 0; }
-.rich figure.highlight.has-lines pre > code { flex: 1 1 auto; padding: 1rem; }
+.rich figure.highlight.has-lines pre > code { flex: 1 1 auto; padding: var(--code-pad); }
 .code-lines {
   flex: 0 0 auto;
   position: sticky;
   left: 0;
-  padding: 1rem 0.85rem 1rem 1rem; /* left aligns the numbers; right = numbers→divider gap */
+  padding: var(--code-pad) 0.85rem var(--code-pad) var(--code-pad); /* left aligns the numbers; right = numbers→divider gap */
   background-color: var(--color-code-bg);
   border-right: 1px solid color-mix(in srgb, var(--color-ink) 12%, transparent);
   color: color-mix(in srgb, var(--color-ink) 45%, transparent);


### PR DESCRIPTION
Adds syntax highlighting for fenced code blocks — the first of the two road-to-1.0 items (SEO is the other).

## Approach: build-time, not JS
kramdown + Rouge already emit token `<span>`s at build time (`<figure class="highlight">`), so highlighting is **pure CSS — zero JS**. A no-JS visitor gets the *fully-coloured* code, identical to everyone else (strictly better than a JS-with-fallback approach).

## Theme
- **gruvbox**, a deliberate **code-block-only exception** to the monochrome palette (documented in DESIGN.md §1/§5).
- Mapped to theme-aware `--hl-*` tokens that flip with the light/dark toggle (same `:has(#theme-toggle:checked)` / `[data-theme]` triggers as the rest of the theme).
- **Every token AA-verified** on `--color-code-bg` in both modes; four light-mode hues (comment/string/type/class) darkened from stock gruvbox-light to clear 4.5:1.
- **Inline `code`** has no language → left as plain text on the code surface (no regression).

## Enhancements (progressive, `_includes/code-enhance.html`)
- **Copy button** (Clipboard API; absent if unavailable).
- **Line-number gutter** — sticky (stays put while code scrolls), `aria-hidden`, non-selectable so copy/readers get only the code.
- With JS off, neither exists — you still get the highlighted block.

## Files
- `_tailwind/highlight.css` — token colours + enhancement chrome; imported by `app.css`.
- `_includes/code-enhance.html` + `default.html` — the JS enhancement.
- `DESIGN.md` — §1/§2 exception, §5 the setup + AA, §8 how to swap themes.

Verified in both themes on a real post (see the linked screenshots in the conversation). Ships as `feat:` → release-please will propose `0.10.0`; `1.0.0` follows once SEO lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)